### PR TITLE
Configure loader.io

### DIFF
--- a/App/gatsby-config.js
+++ b/App/gatsby-config.js
@@ -32,5 +32,13 @@ module.exports = {
       },
       __key: "pages",
     },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `markdown-pages`,
+        path: `./src/markdown-pages`,
+      },
+      __key: "markdown-pages",
+    },
   ],
 };

--- a/App/src/markdown-pages/loaderio-11f9b2166e58edb5ae70c943c6e05758.md
+++ b/App/src/markdown-pages/loaderio-11f9b2166e58edb5ae70c943c6e05758.md
@@ -1,0 +1,6 @@
+---
+slug: "/loaderio-11f9b2166e58edb5ae70c943c6e05758"
+title: "Loader.IO Authentication"
+---
+
+loaderio-11f9b2166e58edb5ae70c943c6e05758

--- a/App/src/pages/{MarkdownRemark.frontmatter__slug}.js
+++ b/App/src/pages/{MarkdownRemark.frontmatter__slug}.js
@@ -1,0 +1,32 @@
+import React from "react"
+import * as Gatsby from "gatsby"
+
+export default function Template({
+  data, // this prop will be injected by the GraphQL query below.
+}) {
+  const { markdownRemark } = data // data.markdownRemark holds your page data
+  const { frontmatter, html } = markdownRemark
+  return (
+    <div className="page-container">
+      <h1>{frontmatter.title}</h1>
+      <div
+        className="page-content"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  )
+}
+
+// using markdownRemark to transform the markdown page to HTML using the format above,
+// retrieves the page from wherever webpack put it
+export const pageQuery = Gatsby.graphql`
+  query($id: String!) {
+    markdownRemark(id: { eq: $id }) {
+      html
+      frontmatter {
+        slug
+        title
+      }
+    }
+  }
+`


### PR DESCRIPTION
[Loader.io](https://loader.io) allows us to stress-test the site and its infrastructure by making lots of requests. It's a powerful tool, and in the wrong hands it could be used to do Denial-of-Service attacks against any site by overloading it with requests. Therefore, Loader.io requires that users place an authorization token on their site to prove that they own it before any testing can be done. This PR sets up Gatsby's ability to transform Markdown into pages, and uses that ability to set up the authorization token for Loader.io.