### PR TITLE
Improve Visibility of Selectable Stations

### DIFF
--- a/App/src/images/map.svg
+++ b/App/src/images/map.svg
@@ -138,23 +138,43 @@
         }
       }
 
+      @keyframes availableStation {
+        0% { 
+          filter: hue-rotate(0deg);
+        }
+        25% {
+          filter: hue-rotate(180deg);
+        }
+        50% {
+          filter: hue-rotate(0deg);
+        }
+        75% {
+          filter: hue-rotate(-180deg);
+        }
+        100% {
+          filter: hue-rotate(0deg);
+        }
+      }
+
       #Atrain {
         stroke: #0060B6;
+        fill: #0060B6;
       }
       #Dtrain {
         stroke: #FF7F00;
+        fill: #FF7F00;
       }
       .station {
-        fill: #FFFFFF;
-        stroke: #FFFFFF;
-        brightness(95%);
         transform-box: fill-box;
         transform-origin: center;
         transition: all .1s ease-in-out;
-        transform: scale(1.2);
+        transform: scale(1.5);
+        filter: brightness(350%);
+        brightness(350%);
+        /* animation: availableStation 2s infinite 1s; */
       }
       .station:hover {
-        transform: scale(1.8);
+        transform: scale(3);
         <!-- filter: url(#pulsate) -->
       }
       .station-highlight {
@@ -174,6 +194,10 @@
         stroke-width: 4;
       }
 
+      .route {
+        filter: brightness(80%);
+        brightness(80%);
+      }
       .route path:hover, .route line:hover {
         filter: brightness(150%);
         filter: drop-shadow(5 5 10 white);

--- a/App/src/images/map.svg
+++ b/App/src/images/map.svg
@@ -290,6 +290,7 @@
   <g id="ShuttleTrain_polygon" data-name="ShuttleTrain polygon">
     <path class="cls-8" d="M1370.9,2179.24a4,4,0,0,1-4-4V1912.08a4,4,0,0,1,8,0v263.16A4,4,0,0,1,1370.9,2179.24Z" transform="translate(-187.26 -54.92)"/>
   </g>
+
   <path id="line2802" class="cls-13" d="M421.93,1261.1v-10.25" transform="translate(-187.26 -54.92)"/>
   <path id="polyline2805" class="cls-13" d="M434.24,1449.09h86v-21h43" transform="translate(-187.26 -54.92)"/>
   <path id="line2807" class="cls-13" d="M360.9,1438.08h10.39" transform="translate(-187.26 -54.92)"/>
@@ -298,7 +299,7 @@
   <path id="polyline2813" class="cls-13" d="M835.14,1600.75h20v20" transform="translate(-187.26 -54.92)"/>
   <path id="line2819" class="cls-14" d="M637.38,1929.12v20" transform="translate(-187.26 -54.92)"/>
   <path id="line2823" class="cls-13" d="M657.63,1798.75H756" transform="translate(-187.26 -54.92)"/>
-  <path id="line2825" class="cls-13" d="M737.4,1789.42v9.33" transform="translate(-187.26 -54.92)"/>
+  <!-- <path id="line2825" class="cls-13" d="M737.4,1789.42v9.33" transform="translate(-187.26 -54.92)"/> -->
   <path id="polyline2827" class="cls-13" d="M935,1869.75H956.9v10" transform="translate(-187.26 -54.92)"/>
   <path id="line2829" class="cls-13" d="M887.4,1916.75v30.5" transform="translate(-187.26 -54.92)"/>
   <path id="path2831" class="cls-13" d="M1073.66,2022.5" transform="translate(-187.26 -54.92)"/>
@@ -306,13 +307,13 @@
   <path id="polyline2843" class="cls-13" d="M1371.57,931.75v21.5l20.83-.5" transform="translate(-187.26 -54.92)"/>
   <path id="polyline2845" class="cls-13" d="M1554.9,1428h-10v-10" transform="translate(-187.26 -54.92)"/>
   <path id="path2847" class="cls-13" d="M1544.9,1418" transform="translate(-187.26 -54.92)"/>
-  <path id="polyline2849" class="cls-13" d="M1631.68,1586.86l9.39-9.38,24.3,24.3" transform="translate(-187.26 -54.92)"/>
+  <!-- <path id="polyline2849" class="cls-13" d="M1631.68,1586.86l9.39-9.38,24.3,24.3" transform="translate(-187.26 -54.92)"/> -->
   <path id="path2851" class="cls-13" d="M1034.9,1429.75" transform="translate(-187.26 -54.92)"/>
   <path id="polyline2853" class="cls-13" d="M936.9,1204.75l5.59-5.59,3.08-3.08-8.67-8.66" transform="translate(-187.26 -54.92)"/>
   <path id="polyline2855" class="cls-13" d="M884.9,1175.25v12.17h52" transform="translate(-187.26 -54.92)"/>
-  <path id="line2859" class="cls-13" d="M361.4,1250.85h82.5" transform="translate(-187.26 -54.92)"/>
+  <!-- <path id="line2859" class="cls-13" d="M361.4,1250.85h82.5" transform="translate(-187.26 -54.92)"/> -->
   <path id="polyline2861" class="cls-13" d="M553.24,1240.85H597.9v20" transform="translate(-187.26 -54.92)"/>
-  <path id="polyline2863" class="cls-13" d="M327.21,1097.25l14-14H359.4" transform="translate(-187.26 -54.92)"/>
+  <!-- <path id="polyline2863" class="cls-13" d="M327.21,1097.25l14-14H359.4" transform="translate(-187.26 -54.92)"/> -->
   <path id="line2865" class="cls-14" d="M726.65,1094.8v-31.75" transform="translate(-187.26 -54.92)"/>
   <path id="polyline2867" class="cls-13" d="M726.65,1094.8v20H704.9" transform="translate(-187.26 -54.92)"/>
   <path id="polyline2869" class="cls-13" d="M726.65,1176.75V1187H705" transform="translate(-187.26 -54.92)"/>

--- a/App/src/images/map.svg
+++ b/App/src/images/map.svg
@@ -89,6 +89,8 @@
 
       .cls-16, .cls-18, .cls-21, .cls-22 {
         fill: #fff;
+        brightness(80%);
+        fill-opacity: 50%;
       }
 
       .cls-17 {
@@ -136,10 +138,6 @@
         }
       }
 
-      .path>line,.path>path {
-        fill: green;
-        stroke: green;
-      }
       #Atrain {
         stroke: #0060B6;
       }
@@ -149,12 +147,17 @@
       .station {
         fill: #FFFFFF;
         stroke: #FFFFFF;
+        brightness(95%);
+        transform-box: fill-box;
+        transform-origin: center;
+        transition: all .1s ease-in-out;
+        transform: scale(1.2);
       }
       .station:hover {
+        transform: scale(1.8);
         <!-- filter: url(#pulsate) -->
       }
       .station-highlight {
-        <!-- transition: all .2s ease-in-out; -->
         fill-opacity: 0;
         <!-- display: none; -->
       }
@@ -250,32 +253,32 @@
         <circle class="station" id="A42_HOYTSCHERMERHORN" cx="785.64" cy="1934.08" r="5" />
       </g>
       <g>
-        <circle class="station-highlight" cx="549.24" cy="1575.41" r="5"  transform="translate(-195.26 -59.92)" />
-        <circle class="station" id="A32_W4TH_WASHINGTONSQ" cx="549.24" cy="1575.41" r="5"  transform="translate(-195.26 -59.92)" />
+        <circle class="station-highlight" cx="353.98" cy="1515.49" r="5" />
+        <circle class="station" id="A32_W4TH_WASHINGTONSQ" cx="353.98" cy="1515.49" r="5" />
       </g>
       <g>
-        <circle class="station-highlight"  cx="2579.63" cy="1645.49" r="7" transform="translate(-195.26 -59.92)"/>
-        <circle class="station end-of-line" id="H11_FARROCKAWAY" cx="2579.63" cy="1645.49" r="7" transform="translate(-195.26 -59.92)"/>
+        <circle class="station-highlight" cx="2384.37" cy="1585.57" r="7" />
+        <circle class="station end-of-line" id="H11_FARROCKAWAY"  cx="2384.37" cy="1585.57" r="7" />
       </g>
       <g>
-        <circle class="station-highlight" cx="1673.71" cy="1606.62" r="5"  transform="translate(-195.26 -59.92)" />
-        <circle class="station" id="A51_BROADWAYJUNCTION" cx="1673.71" cy="1606.62" r="5"  transform="translate(-195.26 -59.92)" />
+        <circle class="station-highlight" cx="1478.45" cy="1546.70" r="5" />
+        <circle class="station" id="A51_BROADWAYJUNCTION" cx="1478.45" cy="1546.70" r="5" />
       </g>
       <g>
-        <circle class="station-highlight" cx="369.79" cy="1088.25" r="5"  transform="translate(-195.26 -59.92)" />
-        <circle class="station" id="A24_COLUMBUSCIRCLE" cx="369.79" cy="1088.25" r="5"  transform="translate(-195.26 -59.92)" />
+        <circle class="station-highlight"  cx="174.53" cy="1028.33" r="5" />
+        <circle class="station" id="A24_COLUMBUSCIRCLE" cx="174.53" cy="1028.33" r="5" />
       </g>
       <g>
-        <circle class="station-highlight" cx="369.79" cy="1255.85" r="5"  transform="translate(-195.26 -59.92)" />
-        <circle class="station" id="A28_Penn-Station" cx="369.79" cy="1255.85" r="5"  transform="translate(-195.26 -59.92)" />
+        <circle class="station-highlight" cx="174.53" cy="1195.93" r="5" />
+        <circle class="station" id="A28_Penn-Station" cx="174.53" cy="1195.93" r="5" />
       </g>
       <g>
-        <circle class="station-highlight" cx="745.9" cy="1794.42" r="5"  transform="translate(-195.26 -59.92)" />
-        <circle class="station" id="A38_FULTON" cx="745.9" cy="1794.42" r="5"  transform="translate(-195.26 -59.92)" />
+        <circle class="station-highlight" cx="550.64" cy="1734.50" r="5" />
+        <circle class="station" id="A38_FULTON" cx="550.64" cy="1734.50" r="5" />
       </g>
       <g>
-        <circle class="station-highlight" cx="1226.9" cy="1941.75" r="5"  transform="translate(-195.26 -59.92)" />
-        <circle class="station" id="A43_Lafayette-Av" cx="1226.9" cy="1941.75" r="5"  transform="translate(-195.26 -59.92)" />
+        <circle class="station-highlight"  cx="1031.64" cy="1881.83" r="5" />
+        <circle class="station" id="A43_Lafayette-Av"  cx="1031.64" cy="1881.83" r="5" />
       </g>
     </g>
   </g>

--- a/App/src/images/map.svg
+++ b/App/src/images/map.svg
@@ -200,7 +200,7 @@
       }
       .route path:hover, .route line:hover {
         filter: brightness(150%);
-        filter: drop-shadow(5 5 10 white);
+        filter: drop-shadow(0 0 10 white);
       }
 
       #viewbox {


### PR DESCRIPTION
This PR improves the visibility and interaction of stations that are selectable.  Non-selectable stations are made dimmer and partially translucent, and the default brightness of subway lines has been decreased.  Selectable stations inherit the color of their line and have their brightness boosted to near-white.  They also increase in size when hovered over.